### PR TITLE
Fixed example app & setup

### DIFF
--- a/Example/README.md
+++ b/Example/README.md
@@ -1,0 +1,31 @@
+## Setup local Repo to fork and experiment/contribute to the lib:
+
+Run the command below to clone the repo after creating a fork:
+
+```
+git clone https://github.com/dvijeniii05/carousel-with-pagination-rn.git
+```
+
+Navigate to the root level of the repo (will have LICENSE file) and run:
+```
+yarn
+```
+The next step is to build the package that will be used in two cases:
+* Built package generated in `lib/` path will be used for publishing 
+* Built package is used when you are running Example app locally
+
+So, to build the pacakge run:
+```
+yarn prepack
+```
+Then navigate to `/Example` folder and build the app using:
+```
+yarn && yarn deps && yarn ios
+```
+OR for Android run:
+```
+yarn && yarn android
+```
+The Example app will pick up the Carousel component from the local build i.e. `lib/` path.
+
+**❗❗IMPORTANT:** The example app doesn't support hot-reloading, so you will have to build the package eveytime when you apply a change. So, once you made a change to the CustomCarousel or PressablePagiantion component, then you will have to run `yarn prepack` from root level and the changes will be visible in your Example app.

--- a/Example/metro.config.js
+++ b/Example/metro.config.js
@@ -6,14 +6,29 @@
  */
 
 const path = require('path');
+const escape = require('escape-string-regexp');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
+const pak = require('../package.json');
+
+const root = path.resolve(__dirname, '..');
+
+const modules = Object.keys({
+  ...pak.peerDependencies,
+});
 
 const extraNodeModules = {
   'carousel-with-pagination-rn': path.resolve(path.join(__dirname, '..')),
 };
-const watchFolders = [path.resolve(path.join(__dirname, '..'))];
 
 module.exports = {
+  projectRoot: __dirname,
+  watchFolders: [root],
   resolver: {
+    blacklistRE: exclusionList(
+      modules.map(
+        m => new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`),
+      ),
+    ),
     extraNodeModules: new Proxy(extraNodeModules, {
       get: (target, name) =>
         name in target
@@ -21,7 +36,6 @@ module.exports = {
           : path.join(process.cwd(), `node_modules/${name}`),
     }),
   },
-  watchFolders,
   transformer: {
     getTransformOptions: async () => ({
       transform: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carousel-with-pagination-rn",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Custom carousel with pagination for React-Native",
   "homepage": "https://github.com/dvijeniii05/carousel-with-pagination-rn/blob/main/README.md",
   "keywords": [
@@ -31,8 +31,8 @@
     "@types/react-native": "^0.71.2",
     "@types/react-test-renderer": "^18.0.0",
     "metro-react-native-babel-preset": "^0.66.1",
-    "react": "^17.2.0",
-    "react-native": "^0.68.5",
+    "react": "^18.2.0",
+    "react-native": "^0.71.0",
     "react-native-builder-bob": "^0.20.3",
     "react-native-gesture-handler": "^2.9.0",
     "react-native-testing-library": "^6.0.0",
@@ -41,7 +41,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-gesture-handler": "*"
   },
   "react-native": "src/index.ts",
   "module": "lib/module/index.js",


### PR DESCRIPTION
Metro config updated to ignore the node_modules folder in the root level of package.
Link added to the local repo to pick up updates for CustomCarousel after each rebuild